### PR TITLE
RoverControl msgs is now resend after reconnection

### DIFF
--- a/MVVM/Model/RoverCommunication.cs
+++ b/MVVM/Model/RoverCommunication.cs
@@ -72,6 +72,7 @@ namespace RoverControlApp.MVVM.Model
 
 		private async void OnMqttConnectionChanged(CommunicationState arg)
 		{
+			await RoverMovementVectorChanged(_pressedKeys.RoverMovement);
 			await RoverCommunication_OnControlStatusChanged(GenerateRoverStatus(connection: arg));
 		}
 

--- a/MVVM/Model/RtspStreamClient.cs
+++ b/MVVM/Model/RtspStreamClient.cs
@@ -95,7 +95,7 @@ namespace RoverControlApp.MVVM.Model
 			var task = 
 				Task.Run(() => Capture = new VideoCapture
 				(
-					$"rtsp://{LocalSettings.Singleton.Camera.ConnectionSettings.Login}:{LocalSettings.Singleton.Camera.ConnectionSettings.Login}"
+					$"rtsp://{LocalSettings.Singleton.Camera.ConnectionSettings.Login}:{LocalSettings.Singleton.Camera.ConnectionSettings.Password}"
 					+ $"@{LocalSettings.Singleton.Camera.ConnectionSettings.Ip}:{LocalSettings.Singleton.Camera.ConnectionSettings.RtspPort}{LocalSettings.Singleton.Camera.ConnectionSettings.RtspStreamPath}")
 				);
 			_matrix = new Mat();


### PR DESCRIPTION
Partially addresses #28 
Already tested and zeroing works nice (Fixes the issue of rover speeding up after RECONNECTION despite no input was given)
- [x] RoverControl zeroing on MQTT reconnect :tada:
- [ ] make RoverControl msgs be at variable refresh (minimum 10 Hz)
